### PR TITLE
Añadido Antonio Morales como nombre de ponente en su charla sobre Kicad

### DIFF
--- a/_posts/2015-12-11-ii-jornadas-hacklab.html
+++ b/_posts/2015-12-11-ii-jornadas-hacklab.html
@@ -204,7 +204,7 @@
             </tr>
             <tr>
                 <td>18:00</td>
-                <td rowspan="2">Taller de Kicad</td>
+                <td rowspan="2">Taller de Kicad<br>(Antonio Morales)</td>
             </tr>
             <tr>
                 <td>18:30</td>


### PR DESCRIPTION
CUIDADO: Añadir este PR antes que el próximo que haga Rubén con la modificación de horario de charlas, vaya que se pisen los cambios, o qué se yo, no entiendo Git.

Aquí sólo se añade el nombre de AMR en su charla.