### PR TITLE
Corrección Markdown y referencia a ¿Ministerio?

### DIFF
--- a/aviso/index.md
+++ b/aviso/index.md
@@ -15,15 +15,15 @@ Según quien sea la entidad que gestione el dominio desde donde se envían las c
 Existe también una segunda clasificación según el plazo de tiempo que permanecen almacenadas en el navegador del cliente, pudiendo tratarse de cookies de sesión o cookies persistentes.
 Por último, existe otra clasificación con cinco tipos de cookies según la finalidad para la que se traten los datos obtenidos: cookies técnicas, cookies de personalización, cookies de análisis, cookies publicitarias y cookies de publicidad comportamental .
 
-####Aceptación de la Política de Cookies
+#### Aceptación de la Política de Cookies
 
 HackLab Almería, con el objeto de dar cumplimiento a la citada normativa, muestra información sobre su Política de cookies a través de una ventana emergente que bloquea la navegación por su portal con cada inicio de sesión. Ante esta información es posible llevar a cabo las siguientes acciones:
 
 Aceptar cookies. No se volverá a visualizar este aviso al acceder a cualquier página del portal durante la presente sesión.
 
-Modificar su configuración. Podrá obtener más información sobre qué son las cookies, conocer la Política de cookies del Ministerio y modificar la configuración de su navegación. Pero esto no evitará que se muestre el aviso sobre cookies al acceder a nuevas páginas del portal.
+Modificar su configuración. Podrá obtener más información sobre qué son las cookies, conocer la Política de cookies de HackLab Almería y modificar la configuración de su navegación. Pero esto no evitará que se muestre el aviso sobre cookies al acceder a nuevas páginas del portal.
 
-####Modificar su Configuración de Cookies
+#### Modificar su Configuración de Cookies
 
 Usted puede restringir, bloquear o borrar las cookies de las páginas web de HackLab Almeria, utilizando su navegador. La configuración en cada tipo de navegador de Internet es diferente, la función de ‘Ayuda” del navegador que usted está usando le mostrará cómo hacerlo. Puede obtener más información en los siguientes enlaces:
 


### PR DESCRIPTION
Los últimos puntos aparecían con "####" literales al faltar un espacio con el texto y no se estaban visualizando como encabezados.
El texto tenía referencia a "conocer la Política de cookies del Ministerio" en vez de al HackLab